### PR TITLE
Reinforce python directory as first thing in PATH

### DIFF
--- a/pre_commit/commands/install_uninstall.py
+++ b/pre_commit/commands/install_uninstall.py
@@ -22,8 +22,9 @@ PRIOR_HASHES = (
     '49fd668cb42069aa1b6048464be5d395',
     '79f09a650522a87b0da915d0d983b2de',
     'e358c9dae00eac5d06b38dfdb1e33a8c',
+    '138fd403232d2ddd5efb44317e38bf03',
 )
-CURRENT_HASH = '138fd403232d2ddd5efb44317e38bf03'
+CURRENT_HASH = 'c145ce377e165a96c892ec6b3d36e24d'
 TEMPLATE_START = '# start templated\n'
 TEMPLATE_END = '# end templated\n'
 

--- a/pre_commit/resources/hook-tmpl
+++ b/pre_commit/resources/hook-tmpl
@@ -9,13 +9,16 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 Z40 = '0' * 40
-ID_HASH = '138fd403232d2ddd5efb44317e38bf03'
+ID_HASH = 'c145ce377e165a96c892ec6b3d36e24d'
 # start templated
 CONFIG = None
 HOOK_TYPE = None
 INSTALL_PYTHON = None
 SKIP_ON_MISSING_CONFIG = None
 # end templated
+OLD_PATH = os.environ['PATH']
+INSTALL_PYTHON_DIRECTORY = os.path.dirname(INSTALL_PYTHON)
+NEW_PATH = '{}{}{}'.format(INSTALL_PYTHON_DIRECTORY, os.path.pathsep, OLD_PATH)
 
 
 class EarlyExit(RuntimeError):


### PR DESCRIPTION
This is used because if you call pre-commit from something that is not a shell (i.e. PyCharm)
AND you use pyenv it will break because something is missing from
the environment.

This should not break any virtualenv because it will just put python's
directory as first in PATH.